### PR TITLE
fix minor spelling, command and naming errors in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ provided.
 
 #### Last steps
 Last but not least checkout some external
-dependencies using `git submodule init --update`.
+dependencies using `git submodule update --init`.
 
 ### Starting pocoweb
 After having gone through all the above steps, one can build and start

--- a/frontend/public_html/doc.html
+++ b/frontend/public_html/doc.html
@@ -22,7 +22,7 @@ suspicious words.</p>
 <p><a href="assets/images/doc/welcome.png" target="_blank" rel="noopener noreferrer"><img width="50%" src="assets/images/doc/welcome.png" alt="Main page" style="max-width:100%;"></a></p>
 <p>PoCoWeb offers:</p>
 <ul>
-<li>Simple user management to enable paralell correction of documents
+<li>Simple user management to enable parallel correction of documents
 packages.</li>
 <li>The possibility to split documents into packages to parallel the
 manual post-correction.</li>

--- a/frontend/public_html/doc.md
+++ b/frontend/public_html/doc.md
@@ -25,7 +25,7 @@ suspicious words.
 <img width="50%" src="assets/images/doc/welcome.png" alt="Main page"/>
 
 PoCoWeb offers:
-* Simple user management to enable paralell correction of documents
+* Simple user management to enable parallel correction of documents
   packages.
 * The possibility to split documents into packages to parallel the
   manual post-correction.

--- a/misc/README.md
+++ b/misc/README.md
@@ -1,5 +1,5 @@
 # Misc
-```$ apt-get install g++-5 libbost-dev libmysqlcppconn-dev make libssl-dev```
+```$ apt-get install g++-5 libboost-dev libmysqlcppconn-dev make libssl-dev```
 
 ## Settings for file upload
 


### PR DESCRIPTION
Found some minor errors in the README and docs while trying to get pocoweb running and fixed them.